### PR TITLE
Update CORs Whitelist

### DIFF
--- a/chajaa/settings/production.py
+++ b/chajaa/settings/production.py
@@ -47,12 +47,17 @@ CACHES = {
 # read the setting value from the environment variable
 DEFAULT_STORAGE_DSN = os.environ.get('DEFAULT_STORAGE_DSN', '')
 
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+
 if DEFAULT_STORAGE_DSN:
     # dsn_configured_storage_class() requires the name of the setting
     DefaultStorageClass = dsn_configured_storage_class('DEFAULT_STORAGE_DSN')
 
     # Django's DEFAULT_FILE_STORAGE requires the class name
     DEFAULT_FILE_STORAGE = 'chajaa.settings.production.DefaultStorageClass'
+    CORS_ORIGIN_WHITELIST.append(
+        "https://" + AWS_STORAGE_BUCKET_NAME
+    )
 else:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
@@ -60,7 +65,6 @@ STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
 # STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
-AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
 AWS_LOCATION = 'static'
 
 AWS_S3_CUSTOM_DOMAIN = '%s.s3-eu-west-1.amazonaws.com' % AWS_STORAGE_BUCKET_NAME


### PR DESCRIPTION
The CORS whitelist restricts what domains we can load files and content from.
We need to add the new Divio buckets to this whitelist.