### PR TITLE
Add libraries needed by cronjobs to the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Web requirments
 wagtail==2.15.3
 wagtailmenus==3.0.2
 psycopg2==2.9.3
@@ -45,3 +46,32 @@ XlsxWriter==3.0.2
 xlwt==1.3.0
 django_storage_url
 python-dotenv==0.19.2
+
+# RapidPro cronjob requirements
+pandas==1.1.5
+# psycopg2-binary==2.8.2 installed in web requirements
+pyodbc==4.0.26
+SQLAlchemy==1.4.31
+sendgrid==6.1.0
+pytest==5.2.2
+pytest-mock==1.11.2
+redshift_connector===2.0.904
+numpy==1.19.5
+
+# Chhaajaa cronjob requirements
+facebook_business
+# pandas installed in Rapidpro cronjob requirements
+# sqlalchemy installed in Rapidpro cronjob requirements
+# psycopg2-binary installed in Rapidpro cronjob requirements
+lxml
+google-api-python-client
+oauth2client
+insta-scrape
+google-api-python-client
+google-auth
+google-auth-oauthlib
+google-auth-httplib2
+nltk
+scikit-learn
+emoji
+regex


### PR DESCRIPTION
Since we are deploying the cronjob scripts along with the web application we need to ensure that the Python libraries needed by the scripts are also installed in the container.