### PR TITLE
Make the sentry APM rate configurable

### DIFF
--- a/chajaa/settings/base.py
+++ b/chajaa/settings/base.py
@@ -12,25 +12,21 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-import dj_database_url
-from django_storage_url import dsn_configured_storage_class
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-sentry_sdk.init(
-    # SENTRY_DSN env var needed for initialisation
-    integrations=[DjangoIntegration()],
+SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
-    traces_sample_rate=1.0,
-
-    # If you wish to associate users to errors (assuming you are using
-    # django.contrib.auth) you may enable sending PII data.
-    send_default_pii=True
-)
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        send_default_pii=True,
+        traces_sample_rate=float(
+            os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.0)
+        ),
+    )
 
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Currently, it is set to monitor all transactions for performance.

Besides using up the quota, it seems like this is not currently needed. The new implementation allows the sample rate via an environment variable and defaults to not enabling APM.